### PR TITLE
Modified apiURL JavaScript method to use apply instead of call

### DIFF
--- a/views/models-collections-and-data.erb
+++ b/views/models-collections-and-data.erb
@@ -67,7 +67,7 @@ var URLs = {
     return "/api/books/";
   },
   subscriptions: function(userId, id) {
-    return "/api/users/'+ userId +'/subscriptions/' + id;
+    return "/api/users/"+ userId +"/subscriptions/" + id;
   }
 }
 


### PR DESCRIPTION
I was implementing the apiURL helper in a project I'm working on - by the way, the book has been very helpful - and was having problems with multiple arguments, similar to subscriptions in the book. Changing to apply sorted that issue.

``` javascript
var URLs = {
    subscriptions: function(userId, id) {
        return "/api/users/"+ userId +"/subscriptions/" + id;
    }
}
```
